### PR TITLE
Added initial publish function to import

### DIFF
--- a/backend/Arena_Import.cs
+++ b/backend/Arena_Import.cs
@@ -20,6 +20,21 @@ public static class Arena_Import
 			else
 				return null;
 		}
+
+	private static void PublishCourses(Arena_Context context, List<Course> courses)
+	{
+		// Currently publishing all generated courses.
+		// Do we want to do additional filtering here before publishing?
+		foreach (Course course in courses.ToList())
+		{
+			if (course.record_status == Record_Status.GENERATED)
+			{
+				course.record_status = Record_Status.APPROVED;
+				context.courses.Update(course);
+			}
+		}
+		context.SaveChanges();
+	}
 	
 	public static int external_import(Arena_Context context, Extapi.Parser method)
 	{
@@ -152,6 +167,7 @@ public static class Arena_Import
 				numOCE++;
 			}
 		}
+		PublishCourses(context, courses);
 		context.SaveChanges();
 		Log.Information($"Linked {numOCE.ToString()}/{courses.Count.ToString()} new courses to orgs, of which {numNewOrgs.ToString()} are newly generated.");
 		return courses.Count;


### PR DESCRIPTION
There is now a function `PublishCourses` that automatically publishes all imported courses (with record status GENERATED). This can be extended to further filter out which imported courses get automatically published.