### PR TITLE
Made hyphen in org number optional in signup

### DIFF
--- a/backend/endpoints/graphql1/Account_Mutation.cs
+++ b/backend/endpoints/graphql1/Account_Mutation.cs
@@ -85,6 +85,7 @@ public class Account_Mutation
 		{
 			return Primitive_Result.REGISTER_ORGID_INVALID;
 		}
+		orgid = orgid.Replace("-", "");
 		Keycloak_Access_Token token1 = Keycloak.token(Arena.config_keycloak_admincli);
 		if (token1.access_token == null)
 		{

--- a/backend/misc/Regexs.cs
+++ b/backend/misc/Regexs.cs
@@ -6,6 +6,6 @@ public static class Regexs
 {
 	
 	//https://bolagsverket.se/ff/foretagsformer/organisationsnummer-1.7902
-	public static readonly Regex organisationsnummer = new Regex(@"^\d{6}-\d{4}$");
+	public static readonly Regex organisationsnummer = new Regex(@"^\d{6}-?\d{4}$");
 
 }

--- a/frontend/src/components/accounts/Signup.js
+++ b/frontend/src/components/accounts/Signup.js
@@ -39,7 +39,7 @@ const Signup = () => {
     if (formData.orgid_se.length < 1) {
       return
     }
-    const validOrgNr = RegExp('^[0-9]{6}-[0-9]{4}$').test(formData.orgid_se)
+    const validOrgNr = RegExp('^[0-9]{6}-?[0-9]{4}$').test(formData.orgid_se)
     if (validOrgNr) {
       setErrors({})
       setValidOrg(true)
@@ -49,7 +49,7 @@ const Signup = () => {
   }, [formData.orgid_se])
 
   function OrgName( {orgId} ) {
-      const {loading, error, data: orgNameData} = useQuery(ORG_NAME_BY_ORGID, {variables: {orgid: orgId}})
+      const {loading, error, data: orgNameData} = useQuery(ORG_NAME_BY_ORGID, {variables: {orgid: orgId.replaceAll('-', '')}})
       if (loading) return null;
       if (error) return `Error! ${error}`;
       if (orgNameData.organizations.nodes[0] && orgNameData.organizations.nodes[0].name) {


### PR DESCRIPTION
It was decided that the default should be without hyphen. Therefore the org number is stored without hyphen in the database.
 
TODO: After merge, existing org numbers that has a hyphen in the database needs to be changed. Useful sql command:
```
update organizations set orgid=replace(orgid, '-', '');
```